### PR TITLE
Check parent folders when opening

### DIFF
--- a/CPAP-Exporter.Tests/Mocks/MockCpapSourceValidator.cs
+++ b/CPAP-Exporter.Tests/Mocks/MockCpapSourceValidator.cs
@@ -1,0 +1,27 @@
+﻿using cpaplib;
+
+namespace CascadePass.CPAPExporter.UI.Tests
+{
+    public class MockCpapSourceValidator : ICpapSourceValidator
+    {
+        public MockCpapSourceValidator(ICpapDataLoader desiredLoader, bool isValid)
+        {
+            this.DesiredLoader = desiredLoader;
+            this.IsValid = isValid;
+        }
+
+        public ICpapDataLoader DesiredLoader { get; set; }
+
+        public bool IsValid { get; set; }
+
+        public ICpapDataLoader GetLoader(string rootFolder)
+        {
+            return this.DesiredLoader;
+        }
+
+        public bool IsCpapFolderStructure(string rootFolder)
+        {
+            return this.IsValid;
+        }
+    }
+}

--- a/CPAP-Exporter.Tests/ViewModels/OpenFilesViewModelTests.cs
+++ b/CPAP-Exporter.Tests/ViewModels/OpenFilesViewModelTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace CascadePass.CPAPExporter.UI.Tests
+﻿namespace CascadePass.CPAPExporter.UI.Tests
 {
     [TestClass]
     public class OpenFilesViewModelTests
@@ -32,6 +30,8 @@ namespace CascadePass.CPAPExporter.UI.Tests
             Assert.IsFalse(viewModel.IsValid);
         }
 
+        #region CanImportFrom
+
         [TestMethod]
         public void CanImportFrom_WithNonExistentFolder_ShouldReturnFalse()
         {
@@ -41,6 +41,52 @@ namespace CascadePass.CPAPExporter.UI.Tests
             Assert.IsFalse(viewModel.CanImportFrom(folderPath));
         }
 
-        //TODO: Add real machine data
+        [TestMethod]
+        public void CanImportFrom_Whitespace_ShouldReturnFalse()
+        {
+            var viewModel = new OpenFilesViewModel();
+
+            Assert.IsFalse(viewModel.CanImportFrom(" "));
+        }
+
+        [TestMethod]
+        public void CanImportFrom_Null_ShouldReturnFalse()
+        {
+            var viewModel = new OpenFilesViewModel();
+
+            Assert.IsFalse(viewModel.CanImportFrom(" "));
+        }
+
+        #endregion
+
+        #region FindImportableParentFolder
+
+        [TestMethod]
+        public void FindImportableParentFolder_ValidFolder()
+        {
+            var folderPath = @"C:\PAP Data\Machine";
+            var viewModel = new OpenFilesViewModel();
+
+            ApplicationComponentProvider.CpapSourceValidator = new MockCpapSourceValidator(null, true);
+
+            var result = viewModel.FindImportableParentFolder(folderPath);
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(result));
+        }
+
+        [TestMethod]
+        public void FindImportableParentFolder_InvalidFolder()
+        {
+            var folderPath = @"C:\PAP Data\Machine";
+            var viewModel = new OpenFilesViewModel();
+
+            ApplicationComponentProvider.CpapSourceValidator = new MockCpapSourceValidator(null, false);
+
+            var result = viewModel.FindImportableParentFolder(folderPath);
+
+            Assert.IsTrue(string.IsNullOrWhiteSpace(result));
+        }
+
+        #endregion
     }
 }

--- a/CPAP-Exporter.Tests/ViewModels/OpenFilesViewModelTests.cs
+++ b/CPAP-Exporter.Tests/ViewModels/OpenFilesViewModelTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace CascadePass.CPAPExporter.UI.Tests
 {
     [TestClass]
+    [DoNotParallelize]
     public class OpenFilesViewModelTests
     {
         #region Title/Description Validation

--- a/CPAP-Exporter.UI/Pages/OpenFiles/OpenFilesView.xaml
+++ b/CPAP-Exporter.UI/Pages/OpenFiles/OpenFilesView.xaml
@@ -16,7 +16,7 @@
                 />
         </CheckBox>
 
-        <Border BorderBrush="LightGray" BorderThickness="0.5" CornerRadius="4" Margin="10">
+        <Border BorderBrush="DarkGray" BorderThickness="0.5" CornerRadius="4" Margin="10">
             <Button BorderBrush="Transparent" Background="Transparent" Command="{Binding BrowseCommand}">
                 <StackPanel Orientation="Horizontal">
                     <Image Source="pack://application:,,,/Images/OpenFolder.png" Style="{StaticResource NavigationButtonImage}" />
@@ -33,7 +33,7 @@
         <ItemsControl ItemsSource="{Binding Folders}" Margin="10">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Border BorderBrush="LightGray" BorderThickness="0.5" CornerRadius="4" Width="Auto">
+                    <Border BorderBrush="LightGray" BorderThickness="0.5" CornerRadius="4" Width="Auto" Margin="0,5,0,5">
                         <Button BorderBrush="Transparent" Background="Transparent" Command="{Binding ElementName=OpenFilesControl, Path=DataContext.OpenCommand}" CommandParameter="{Binding .}">
                             <StackPanel Orientation="Horizontal">
                                 <Image Source="pack://application:,,,/Images/OpenFolder.png" Style="{StaticResource NavigationButtonImage}" />

--- a/CPAP-Exporter.UI/Resources.Designer.cs
+++ b/CPAP-Exporter.UI/Resources.Designer.cs
@@ -394,6 +394,15 @@ namespace CascadePass.CPAPExporter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t find PAP data in &apos;{0}&apos; or any parent folder..
+        /// </summary>
+        public static string NoPapData {
+            get {
+                return ResourceManager.GetString("NoPapData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open the PAP files you&apos;d like to export.  They can be on an SD card, or CPAP Exporter can read them from any folder..
         /// </summary>
         public static string PageDesc_OpenFiles {

--- a/CPAP-Exporter.UI/Resources.resx
+++ b/CPAP-Exporter.UI/Resources.resx
@@ -294,4 +294,7 @@
   <data name="FolderIsNotPAP" xml:space="preserve">
     <value>The folder '{0}' does not contain PAP data</value>
   </data>
+  <data name="NoPapData" xml:space="preserve">
+    <value>Can't find PAP data in '{0}' or any parent folder.</value>
+  </data>
 </root>


### PR DESCRIPTION
If CPAP-Exporter can't find valid PAP files in a folder, the user may have browsed too far and deep.  Automatically check parent folders on their behalf.

For example, if the user clicks open and browses to C:\SD\ASV\DATALOG\20250217, the software will automatically find C:\SD\ASV as the correct root.