### PR TITLE
Run Core.Tests in Main

### DIFF
--- a/.github/workflows/BuildMain.yml
+++ b/.github/workflows/BuildMain.yml
@@ -25,6 +25,10 @@ jobs:
       run: |
         dotnet build CPAP-Exporter.Core/CPAP-Exporter.Core.csproj --configuration Release
         dotnet build CPAP-Exporter.UI/CPAP-Exporter.UI.csproj --configuration Release
+        dotnet build CPAP-Exporter.Core.Tests/CPAP-Exporter.Core.Tests.csproj --configuration Release
+
+    - name: Run tests
+      run: dotnet test --configuration Release
 
     - name: Archive build artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Run tests against core logic, which do not involve dependency injection, after merging to main, to help catch issues quickly should they arise.