### PR TITLE
Simplify Select Signals feature

### DIFF
--- a/CPAP-Exporter.UI/Pages/SelectSignals/SelectSignalsView.xaml
+++ b/CPAP-Exporter.UI/Pages/SelectSignals/SelectSignalsView.xaml
@@ -7,37 +7,22 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
-    <ScrollViewer>
-        <StackPanel>
-            <DataGrid
-                ItemsSource="{Binding Signals}"
-                Background="Transparent"
-                CanUserAddRows="False" CanUserDeleteRows="False"
-                AutoGenerateColumns="False" HeadersVisibility="Column"
-                EnableRowVirtualization="True" EnableColumnVirtualization="True"
-                VerticalScrollBarVisibility="Auto"
-                HorizontalScrollBarVisibility="Auto"
-                >
-                <DataGrid.Columns>
-                    <DataGridCheckBoxColumn Header="Export" Binding="{Binding IsSelected}" />
-                    <DataGridTextColumn Header="Signal" Binding="{Binding SignalInfo.Name}" />
-                    <DataGridTextColumn Header="Frequency" Binding="{Binding SignalInfo.FrequencyInHz}" />
-                    <DataGridTextColumn Header="SampleCount" Binding="{Binding SignalInfo.SampleCount, StringFormat=N0}" />
-                    <DataGridTextColumn Header="Unit" Binding="{Binding SignalInfo.UnitOfMeasurement}" />
-                    <DataGridTextColumn Header="Example Data" Binding="{Binding SignalInfo.Sample}" />
-                </DataGrid.Columns>
-            </DataGrid>
-
-            <StackPanel Orientation="Horizontal" Margin="0,15,0,10">
-                <Image Source="/Images/Document.png" />
-                <TextBlock Text="Example CSV Export" Style="{StaticResource Header}" FontSize="{DynamicResource FontSize.Large}" />
-            </StackPanel>
-
-            <TextBlock
-                Text="{Binding SampleCSV}"
-                Style="{StaticResource FileSample}"
-                />
-        </StackPanel>
-    </ScrollViewer>
-
+    <DataGrid
+        ItemsSource="{Binding Signals}"
+        Background="Transparent"
+        CanUserAddRows="False" CanUserDeleteRows="False"
+        AutoGenerateColumns="False" HeadersVisibility="Column"
+        EnableRowVirtualization="True" EnableColumnVirtualization="True"
+        VerticalScrollBarVisibility="Auto"
+        HorizontalScrollBarVisibility="Auto"
+        >
+        <DataGrid.Columns>
+            <DataGridCheckBoxColumn Header="Export" Binding="{Binding IsSelected}" />
+            <DataGridTextColumn Header="Signal" Binding="{Binding SignalInfo.Name}" />
+            <DataGridTextColumn Header="Frequency" Binding="{Binding SignalInfo.FrequencyInHz}" />
+            <DataGridTextColumn Header="SampleCount" Binding="{Binding SignalInfo.SampleCount, StringFormat=N0}" />
+            <DataGridTextColumn Header="Unit" Binding="{Binding SignalInfo.UnitOfMeasurement}" />
+            <DataGridTextColumn Header="Example Data" Binding="{Binding SignalInfo.Sample}" />
+        </DataGrid.Columns>
+    </DataGrid>
 </UserControl>


### PR DESCRIPTION
Remove text showing a preview of the CSV export, users don't need it, it's just clutter.