### PR TITLE
Remove status control

### DIFF
--- a/CPAP-Exporter.UI/MainWindow.xaml
+++ b/CPAP-Exporter.UI/MainWindow.xaml
@@ -10,12 +10,6 @@
         Title="{x:Static local:Resources.Window_Title}">
 
     <DockPanel>
-        <local:StatusStrip
-            DockPanel.Dock="Bottom"
-            x:Name="StatusStrip"
-            DataContext="{Binding ElementName=PageViewer, Path=DataContext.CurrentView.DataContext}"
-            />
-        
         <local:NavigationBar
             DockPanel.Dock="Left"
             x:Name="NavBar"

--- a/CPAP-Exporter.UI/MainWindow.xaml.cs
+++ b/CPAP-Exporter.UI/MainWindow.xaml.cs
@@ -19,7 +19,6 @@ namespace CascadePass.CPAPExporter
             this.userSettings = navigationViewModel.ExportParameters.UserPreferences;
 
             this.PageViewer.DataContext = navigationViewModel;
-            this.StatusStrip.DataContext = new StatusBarViewModel() { MainWindow = this, NavigationViewModel = navigationViewModel };
 
             navigationViewModel.PropertyChanged += NavigationViewModel_PropertyChanged;
 
@@ -56,10 +55,8 @@ namespace CascadePass.CPAPExporter
         private void NavigationViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             //if (string.Equals(e.PropertyName, nameof(NavigationViewModel.CurrentView)))
-            {
-                var statusStripBinding = BindingOperations.GetBindingExpression(this.StatusStrip, DataContextProperty);
-                statusStripBinding?.UpdateTarget();
-            }
+            //{
+            //}
 
             //if (string.Equals(e.PropertyName, nameof(PageViewModel.IsBusy)))
             //{


### PR DESCRIPTION
Remove the status bar control from the bottom of the window.  At this point, we're leaving the code that generates status updates in place, but unused.  Going forward, there will be a new visual paradigm to communicate this info, and the existing code already reports the correct data at the right time, so leave it for a future refactor.