### PR TITLE
Add blank space to PageView

### DIFF
--- a/CPAP-Exporter.UI/Pages/SelectNights/SelectNightsViewModel.cs
+++ b/CPAP-Exporter.UI/Pages/SelectNights/SelectNightsViewModel.cs
@@ -3,9 +3,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 
@@ -33,6 +31,7 @@ namespace CascadePass.CPAPExporter
         /// </summary>
         public SelectNightsViewModel() : base(Resources.PageTitle_SelectNights, Resources.PageDesc_SelectNights)
         {
+            this.ReservedNotificationHeight = 50;
         }
 
         public SelectNightsViewModel(ExportParameters exportParameters) : this()
@@ -158,7 +157,6 @@ namespace CascadePass.CPAPExporter
             this.IsBusy = true;
             this.ShowBusyStatus();
             this.ExportParameters.SourcePath = folder;
-            ApplicationComponentProvider.Status.StatusText = string.Format(Resources.ReadingFolder, folder);
 
             // Prepare to load reports
             List<DailyReport> reports = null;
@@ -171,7 +169,7 @@ namespace CascadePass.CPAPExporter
             }
             catch (Exception ex)
             {
-                ApplicationComponentProvider.Status.StatusText += ex.ToString();
+                Application.Current.Dispatcher.Invoke(() => { this.StatusContent = new ErrorToast(ex.Message); });
             }
 
             // And now it's time to process them.
@@ -259,8 +257,6 @@ namespace CascadePass.CPAPExporter
                 this.ShowDefaultStatusMessage();
                 return;
             }
-
-            ApplicationComponentProvider.Status.StatusText = Resources.Working;
 
             Task.Run(() =>
             {

--- a/CPAP-Exporter.UI/Pages/SelectSignals/SelectSignalsViewModel.cs
+++ b/CPAP-Exporter.UI/Pages/SelectSignals/SelectSignalsViewModel.cs
@@ -13,6 +13,7 @@ namespace CascadePass.CPAPExporter
 
         public SelectSignalsViewModel() : base(Resources.PageTitle_SelectSignals, Resources.PageDesc_SelectSignals)
         {
+            this.ReservedNotificationHeight = 50;
         }
 
         public SelectSignalsViewModel(ExportParameters exportParameters) : this()

--- a/CPAP-Exporter.UI/Views/PageView.xaml
+++ b/CPAP-Exporter.UI/Views/PageView.xaml
@@ -16,8 +16,8 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition MinHeight="{Binding CurrentView.DataContext.ReservedNotificationHeight}" />
             </Grid.RowDefinitions>
 
             <TextBlock
@@ -50,6 +50,7 @@
             <local:AuraPresenter
                 x:Name="StatusHost"
                 Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2"
+                VerticalAlignment="Top"
                 Visibility="{Binding CurrentView.DataContext.StatusContent, Converter={StaticResource NullableObjectToVisibilityConverter}}"
                 Content="{Binding CurrentView.DataContext.StatusContent}">
                 <local:AuraPresenter.StylingCueProvider>


### PR DESCRIPTION
Leave empty space in the page view template and use it on pages that create toasts, to prevent page content from being pushed down.